### PR TITLE
Convert background Image component to typescript

### DIFF
--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -14,8 +14,11 @@ const useStyles = makeStyles((theme) => ({
     zIndex: 0
   }
 }));
-
-function BackgroundImage(props) {
+interface BackgroundImageProps {
+  image: string;
+  opacity: number;
+}
+function BackgroundImage(props: BackgroundImageProps) {
   const classes = useStyles();
 
   const { image, opacity, ...otherProps } = props;


### PR DESCRIPTION
 Define prop types for Background Image

Line 17-21

```javaSCript
interface BackgroundImageProps {
  image: string;
  opacity: number;
}


...BackgroundImage(props:BackgroundImageProps)...

```
 Issue: #20 