### PR TITLE
Convert custome document file to typescript

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,16 +1,22 @@
 import React from "react";
-import Document, { Html, Head, Main, NextScript } from "next/document";
+import Document, {
+  DocumentContext,
+  Html,
+  Head,
+  Main,
+  NextScript
+} from "next/document";
 import { ServerStyleSheets } from "@material-ui/core/styles";
 
 export default class MyDocument extends Document {
-  static async getInitialProps(ctx) {
+  static async getInitialProps(ctx: DocumentContext) {
     // Render app and page and get the context of the page with collected side effects.
     const sheets = new ServerStyleSheets();
     const originalRenderPage = ctx.renderPage;
 
     ctx.renderPage = () =>
       originalRenderPage({
-        enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
+        enhanceApp: (App) => (props) => sheets.collect(<App {...props} />)
       });
 
     const initialProps = await Document.getInitialProps(ctx);
@@ -20,8 +26,8 @@ export default class MyDocument extends Document {
       // Styles fragment is rendered after the app and page rendering finish.
       styles: [
         ...React.Children.toArray(initialProps.styles),
-        sheets.getStyleElement(),
-      ],
+        sheets.getStyleElement()
+      ]
     };
   }
 


### PR DESCRIPTION
 Change file name and import DocumentContext to define ctx prop.

Line 2 & 12
```javaScript
import Document, {..., DocumentContext, ...}

...
 static aync getInitialProps(ctx: DocumentContext)...
...
```
 Issues: #53